### PR TITLE
Update the “Single register of planning” project page

### DIFF
--- a/content/project/single-register-of-planning/index.md
+++ b/content/project/single-register-of-planning/index.md
@@ -3,26 +3,24 @@ title: "Single register of planning"
 status: alpha
 ---
 
-Overview here...
-
-{{< govuk-section-break "xl" >}}
-
-## Prototypes
-
-We've not yet started prototype for this project.
+[mySociety](https://www.mysociety.org) and the [Ministry of Housing, Communities & Local Government](https://www.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government) are exploring how to make trustworthy, up-to-date planning application data easier to find, use, and build into services.
 
 {{< govuk-section-break "xl" >}}
 
 ## Next steps
 
+* Develop a simple model of planning application data flows, by reviewing existing literature and data sources, and interviewing domain experts from <abbr title="Ministry of Housing, Communities & Local Government">MHCLG</abbr>, <abbr title="Greater London Assembly">GLA</abbr>, <abbr title="Local Government Association">LGA</abbr>, and Future Cities Catapult.
+* Understand what planning permission data is needed by developers, PropTech companies, and analysts.
+* Understand what data the different planning register systems can provide.
+
 {{< govuk-section-break "xl" >}}
 
-## Data fields
+## Prototypes
 
-The specification has not yet defined.
+We’ve not yet started any prototypes for this project.
 
 {{< govuk-section-break "xl" >}}
 
 ## Publications
 
-There are no publication for this specification.
+There are no publications for this project.


### PR DESCRIPTION
Adds a description and list of next steps to the planning permissions project page.

@mattlucht – hope this is acceptable! 😄 

![image](https://user-images.githubusercontent.com/739624/51331931-a6e30300-1a72-11e9-85c5-a7cfe341bf7b.png)

/cc @emilydrk