### PR TITLE
Update planning permissions project page with discovery update 

### DIFF
--- a/content/project/single-register-of-planning/_contents.md
+++ b/content/project/single-register-of-planning/_contents.md
@@ -1,0 +1,6 @@
+Contents
+
+- [Goals](#goals)
+- [Discovery](#discovery-goals)
+- [Prototypes](#prototypes)
+- [Publications](#publications)

--- a/content/project/single-register-of-planning/_contents.md
+++ b/content/project/single-register-of-planning/_contents.md
@@ -2,5 +2,6 @@ Contents
 
 - [Goals](#goals)
 - [Discovery](#discovery)
+- [Blog posts](#blog-posts)
 - [Prototypes](#prototypes)
 - [Publications](#publications)

--- a/content/project/single-register-of-planning/_contents.md
+++ b/content/project/single-register-of-planning/_contents.md
@@ -1,6 +1,6 @@
 Contents
 
 - [Goals](#goals)
-- [Discovery](#discovery-goals)
+- [Discovery](#discovery)
 - [Prototypes](#prototypes)
 - [Publications](#publications)

--- a/content/project/single-register-of-planning/index.md
+++ b/content/project/single-register-of-planning/index.md
@@ -1,17 +1,55 @@
 ---
 title: "Single register of planning"
 status: alpha
+type: project
+hasContent: true
 ---
 
 [mySociety](https://www.mysociety.org) and the [Ministry of Housing, Communities & Local Government](https://www.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government) are exploring how to make trustworthy, up-to-date planning application data easier to find, use, and build into services.
 
 {{< govuk-section-break "xl" >}}
 
-## Next steps
+## Goals
 
-* Develop a simple model of planning application data flows, by reviewing existing literature and data sources, and interviewing domain experts from <abbr title="Ministry of Housing, Communities & Local Government">MHCLG</abbr>, <abbr title="Greater London Assembly">GLA</abbr>, <abbr title="Local Government Association">LGA</abbr>, and Future Cities Catapult.
-* Understand what planning permission data is needed by developers, PropTech companies, and analysts.
-* Understand what data the different planning register systems can provide.
+Our goals for this project are to:
+
+* **Prototype:** Prototype how to make planning applications available as a collection of data in order to show how a beta system with more complete data could work.
+* **Inspire:** Create, or support the creation of, experimental prototypes of what can be done with this data, in order to demonstrate the potential value of making an open index of this data.
+* **Plan for scale:** Explore options for how to scale from a prototype to a production system, and the challenges that would need to be addressed, in order to show how to turn this into a sustainable solution.
+* **Share our approach:** Document and share our user research work, findings, prototypes and other outputs openly in order to gather wider input and feedback, and so others can learn from this work.
+
+{{< govuk-section-break "xl" >}}
+
+## Discovery
+
+### Goals
+
+During discovery, we’re trying to understand more about planning application data flows, understand user needs for planning application data and understand more about the technical constraints and capabilities of the underlying systems.
+
+### What we've done
+
+We’ve so far spoken to 18 different people: 6 in local government planning or IT, 6 in proptech businesses, 3 individuals who know planning data (Andrew Speakman, Adrian Short and Richard Pope), 2 MHCLG experts and 1 system provider (the planning portal).
+
+We’ve been making progress in understanding the needs of users for a data source, the domain of planning data, and how this data flows through different systems and organisations.
+
+Here are four questions that have emerged as being particularly important and that we are focusing on:
+
+* how do you get more structured data flowing through the system?
+* how do we help users of this data tie related planning submissions together and to other datasets they might be using?
+* what capabilities does a central data source need to have for it to be useful to the intended users?
+* how do we get the ~360 or so local planning authorities across England all releasing it in the same format?
+* how do we get structured and reliable data on commencements and completions?
+
+On this last point, it looks as if the answer here lies in linking planning application data to a different dataset — building control data. There is enough complexity there that it may warrant a separate investigation of its own.
+
+### What's next
+
+We’re now writing up the interviews and consolidating the findings to help inform our decisions on where to focus in alpha.
+
+We will also be identifying gaps in our knowledge and looking to schedule more conversations targeted to fill in these gaps. For example:
+
+* we want to speak to LPAs using a variety of office systems (Northgate and Ocella in particular) to find out how much of what we've discovered so far about how data is modelled and managed is consistent across different systems
+* we want to start talking to system providers about what their systems can do and options for data extraction or integration
 
 {{< govuk-section-break "xl" >}}
 

--- a/content/project/single-register-of-planning/index.md
+++ b/content/project/single-register-of-planning/index.md
@@ -11,7 +11,7 @@ hasContent: true
 
 ## Goals
 
-Our goals for this project are to:
+Our goals for [this project](https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/8075) are to:
 
 * **Prototype:** Prototype how to make planning applications available as a collection of data in order to show how a beta system with more complete data could work.
 * **Inspire:** Create, or support the creation of, experimental prototypes of what can be done with this data, in order to demonstrate the potential value of making an open index of this data.
@@ -50,6 +50,12 @@ We will also be identifying gaps in our knowledge and looking to schedule more c
 
 * we want to speak to LPAs using a variety of office systems (Northgate and Ocella in particular) to find out how much of what we've discovered so far about how data is modelled and managed is consistent across different systems
 * we want to start talking to system providers about what their systems can do and options for data extraction or integration
+
+{{< govuk-section-break "xl" >}}
+
+## Blog posts
+
+You can read blog posts about this project [here](https://digital-land.github.io/blog-post/).
 
 {{< govuk-section-break "xl" >}}
 

--- a/content/project/single-register-of-planning/index.md
+++ b/content/project/single-register-of-planning/index.md
@@ -28,7 +28,7 @@ During discovery, we’re trying to understand more about planning application d
 
 ### What we've done
 
-We’ve so far spoken to 18 different people: 6 in local government planning or IT, 6 in proptech businesses, 3 individuals who know planning data (Andrew Speakman, Adrian Short and Richard Pope), 2 MHCLG experts and 1 system provider (the planning portal).
+We’ve so far spoken to 18 different people: 6 in local government planning or IT, 6 in proptech businesses, 3 individuals who know planning data, 2 MHCLG experts and 1 system provider (the planning portal).
 
 We’ve been making progress in understanding the needs of users for a data source, the domain of planning data, and how this data flows through different systems and organisations.
 


### PR DESCRIPTION
This replaces #70.

Adds a summary of project goals, details on discovery: what we're trying to do, what we've done, and what's next, and links to the blog posts page.

In future, we could replace the blog posts link with automatically generated titles or snippets of the posts.