### PR TITLE
Tidy up planning register project page

### DIFF
--- a/content/project/single-register-of-planning/_contents.md
+++ b/content/project/single-register-of-planning/_contents.md
@@ -3,3 +3,4 @@ Contents
 - [Goals](#goals)
 - [Discovery](#discovery)
 - [Prototypes](#prototypes)
+- [Blog posts](#related-blog-posts)

--- a/content/project/single-register-of-planning/_contents.md
+++ b/content/project/single-register-of-planning/_contents.md
@@ -2,6 +2,4 @@ Contents
 
 - [Goals](#goals)
 - [Discovery](#discovery)
-- [Blog posts](#blog-posts)
 - [Prototypes](#prototypes)
-- [Publications](#publications)

--- a/content/project/single-register-of-planning/_introduction.md
+++ b/content/project/single-register-of-planning/_introduction.md
@@ -1,0 +1,1 @@
+[mySociety](https://www.mysociety.org) and the [Ministry of Housing, Communities & Local Government](https://www.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government) are exploring how to make trustworthy, up-to-date planning application data easier to find, use, and build into services.

--- a/content/project/single-register-of-planning/index.md
+++ b/content/project/single-register-of-planning/index.md
@@ -5,10 +5,6 @@ type: project
 hasContent: true
 ---
 
-[mySociety](https://www.mysociety.org) and the [Ministry of Housing, Communities & Local Government](https://www.gov.uk/government/organisations/ministry-of-housing-communities-and-local-government) are exploring how to make trustworthy, up-to-date planning application data easier to find, use, and build into services.
-
-{{< govuk-section-break "xl" >}}
-
 ## Goals
 
 Our goals for [this project](https://www.digitalmarketplace.service.gov.uk/digital-outcomes-and-specialists/opportunities/8075) are to:

--- a/content/project/single-register-of-planning/index.md
+++ b/content/project/single-register-of-planning/index.md
@@ -53,18 +53,8 @@ We will also be identifying gaps in our knowledge and looking to schedule more c
 
 {{< govuk-section-break "xl" >}}
 
-## Blog posts
-
-You can read blog posts about this project [here](https://digital-land.github.io/blog-post/).
-
-{{< govuk-section-break "xl" >}}
-
 ## Prototypes
 
 We’ve not yet started any prototypes for this project.
 
 {{< govuk-section-break "xl" >}}
-
-## Publications
-
-There are no publications for this project.

--- a/layouts/partials/related-blog-posts.html
+++ b/layouts/partials/related-blog-posts.html
@@ -13,7 +13,7 @@
 
 {{ if len $relatedBlogPosts }}
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-  <h2>Related blog posts</h2>
+  <h2 id="related-blog-posts">Related blog posts</h2>
   {{ range $relatedBlogPosts }}
     {{ partial "blog-post-preview.html" . }}
   {{ end }}


### PR DESCRIPTION
This PR tidies up the planning register project page in a few ways:
- Removes publications section and duplicate blog post section
- Adds ability to link to auto-generated related blog posts
- Reworks in-page contents to reflect changes
- Moves project introduction to markdown fragment to match other project page layouts