### PR TITLE
Fix RSS Link warnings

### DIFF
--- a/layouts/blog-post/list.html
+++ b/layouts/blog-post/list.html
@@ -1,6 +1,8 @@
 {{ define "head" }}
     <link rel="stylesheet" media="all" href="/stylesheets/main.css" />
-    <link rel="alternate" type="application/rss+xml" href="{{ .RSSLink }}" title="{{ .Title | safeHTML }} - {{ $.Site.Title | safeHTML }}" />
+    {{ with .OutputFormats.Get "rss" -}}
+      <link rel="{{ .Rel }}" type="application/rss+xml" href="{{ .Permalink }}" title="{{ $.Title | safeHTML }} - {{ $.Site.Title | safeHTML }}" />
+    {{ end -}}
 {{ end }}
 
 {{ define "content_inner" }}

--- a/layouts/blog-post/single.html
+++ b/layouts/blog-post/single.html
@@ -1,6 +1,8 @@
 {{ define "head" }}
     <link rel="stylesheet" media="all" href="/stylesheets/main.css" />
-    <link rel="alternate" type="application/rss+xml" href="{{ .Parent.RSSLink }}" title="{{ .Parent.Title | safeHTML }} - {{ $.Site.Title | safeHTML }}" />
+    {{ with $.Parent.OutputFormats.Get "rss" -}}
+      <link rel="{{ .Rel }}" type="application/rss+xml" href="{{ .Permalink }}" title="{{ $.Parent.Title | safeHTML }} - {{ $.Site.Title | safeHTML }}" />
+    {{ end -}}
 {{ end }}
 
 {{ define "content_inner" }}


### PR DESCRIPTION
This changes the deprecated `.RSSLink` in favour of `with .OutputFormats.Get "rss"` blocks.