### PR TITLE
Add line to deploy script to fetch latest committed dl-frontend.css

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,9 @@ rm -rf public/*
 # Build the project.
 hugo
 
+# get latest committed version of dl-frontend.css
+wget -O public/stylesheets/dl-frontend.css https://raw.githubusercontent.com/digital-land/digital-land-frontend/master/application/static/stylesheets/dl-frontend.css
+
 # Go To Public folder
 cd public
 # Add changes to git.


### PR DESCRIPTION
Adding this line means every time the digital land site is built it will make sure it uses the latest build of the dl-frontend.css.