### PR TITLE
Adds WKT custom boundary documentation

### DIFF
--- a/content/architecture/documentation/index.md
+++ b/content/architecture/documentation/index.md
@@ -258,7 +258,7 @@ A Fact is a piece of information relating to an entity. Entities are generated f
 
 #### WKT Boundary Validation
 
-When [normalising a WKT](https://github.com/digital-land/digital-land-python/blob/main/digital_land/datatype/wkt.py) entity, it is validated by checking whether it lies within a boundary. The boundary is required to be a WKT of type Polygon or MultiPolygon. If there is no given boundary, or if the given boundary is of the wrong type, a default bounding box of England is used for validation.
+When [normalising a WKT](https://github.com/digital-land/digital-land-python/blob/main/digital_land/datatype/wkt.py) entity, it is validated by checking whether it lies within a boundary. The default boundary is a bounding box of England, but a custom boundary can be used. The custom boundary is required to be a WKT of type Polygon or MultiPolygon. If there is no custom boundary, or if the custom boundary is of the wrong type, the default bounding box of England is used for validation.
 
 ## List of Datasets
 

--- a/content/architecture/documentation/index.md
+++ b/content/architecture/documentation/index.md
@@ -254,6 +254,12 @@ A Fact is a piece of information relating to an entity. Entities are generated f
 * `end-date` - optional, date at which fact ceases to apply
 * `entry-date` - optional, date at which fact was first collected
 
+### Processes
+
+#### WKT Boundary Validation
+
+When [normalising a WKT](https://github.com/digital-land/digital-land-python/blob/main/digital_land/datatype/wkt.py) entity, it is validated by checking whether it lies within a boundary. The boundary is required to be a WKT of type Polygon or MultiPolygon. If there is no given boundary, or if the given boundary is of the wrong type, a default bounding box of England is used for validation.
+
 ## List of Datasets
 
 ## External Links

--- a/content/architecture/documentation/index.md
+++ b/content/architecture/documentation/index.md
@@ -258,7 +258,7 @@ A Fact is a piece of information relating to an entity. Entities are generated f
 
 #### WKT Boundary Validation
 
-When [normalising a WKT](https://github.com/digital-land/digital-land-python/blob/main/digital_land/datatype/wkt.py) entity, it is validated by checking whether it lies within a boundary. The default boundary is a bounding box of England, but a custom boundary can be used. The custom boundary is required to be a WKT of type Polygon or MultiPolygon. If there is no custom boundary, or if the custom boundary is of the wrong type, the default bounding box of England is used for validation.
+When [normalising a WKT](https://github.com/digital-land/digital-land-python/blob/main/digital_land/datatype/wkt.py) entity, it is validated by checking whether it lies within a boundary. The default boundary is a bounding box of England, but a custom boundary can be input into the normalise function to be used instead. The custom boundary is required to be a WKT of type Polygon or MultiPolygon. If there is no custom boundary, or if the custom boundary is of the wrong type, the default bounding box of England is used for validation.
 
 ## List of Datasets
 


### PR DESCRIPTION
Adds section for documentation on the custom boundary functionality being added to the WKT normalisation process in [this PR](https://github.com/digital-land/digital-land-python/pull/135)